### PR TITLE
Fix deprecated char in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [metadata]
-description-file=readme.md
+description_file=readme.md
 license_files=license.txt


### PR DESCRIPTION
Today I faced issue installing lftk with setuptools v78.0.1. Since 2021, the use of hyphens ("-") in setup.cfg has been deprecated. Setuptools version 78 was scheduled to enforce this deprecation today, but due to widespread compatibility issues, the setuptools team has postponed enforcement until 2026 and reverted back the behaviour in v78.0.2. Be aware that after 2026, installations using hyphenated names in setup.cfg will fail when setuptools finally implements this change again.